### PR TITLE
Introduce $piglatin_domains and piglatin_domains filter

### DIFF
--- a/piglatin.php
+++ b/piglatin.php
@@ -109,7 +109,7 @@ class PigLatin {
 			return $translated;
 		}
 
-		return PigLatin::translation2pig($number == 1? $single : $plural);
+		return PigLatin::translation2pig( $number == 1 ? $single : $plural );
 	}
 
 	public static function ngettext_with_context( $translation, $single, $plural, $number, $context, $domain ) {
@@ -117,7 +117,7 @@ class PigLatin {
 			return $translated;
 		}
 
-		return PigLatin::translation2pig($number == 1? $single : $plural);
+		return PigLatin::translation2pig( $number == 1 ? $single : $plural );
 	}
 
 }


### PR DESCRIPTION
Fixes #4. Adds both the `$piglatin_domains` global variable and a `piglatin_domains` filter.

By default, allows all domains unless either of the above is used, in which case, only uses domains set in that variable. To use, add something like this to your `wp-config.php`:

``` php
$piglatin_domains = [
    'myplugin' => true,
];
```
