### PR TITLE
Make this plugin's headers translatable

### DIFF
--- a/piglatin.php
+++ b/piglatin.php
@@ -6,6 +6,7 @@
  * Version: 0.1
  * Author: Nikolay Bachiyski
  * Author URI: http://nikolay.bg/
+ * Text Domain: piglatin
  */
 
 class PigLatin {


### PR DESCRIPTION
WordPress makes plugin headers translatable, if the `Text Domain` header is present. Adding this means Pig Latin will now convert it's own plugin headers into pig latin, as it does with other plugins that use the `Text Domain` header.
